### PR TITLE
change file name insert character to vertical bar

### DIFF
--- a/HBBatchBeast/modules/worker1.js
+++ b/HBBatchBeast/modules/worker1.js
@@ -358,7 +358,7 @@ process.on('message', (m) => {
         }
 
         var presetSplit
-        presetSplit = preset.split(',')
+        presetSplit = preset.split('|')
         var workerCommand = "";
 
         if (process.platform == 'win32' && handBrakeMode == true) {


### PR DESCRIPTION
Addresses issue #70 by changing the character used to designate the file name from a comma to a vertical bar. This allows for complex ffmpeg command lines since commas are used as separators in more complex ffmpeg parameters. Documentation has not been updated to reflect the change.
